### PR TITLE
NAS Name fix and firmware info added in sysinfo

### DIFF
--- a/check_qnap3.sh
+++ b/check_qnap3.sh
@@ -750,9 +750,10 @@ elif [ "$strpart" == "sysinfo" ]; then
 	model=$(snmpget -v1 -c "$strCommunity" "$strHostname"  .1.3.6.1.4.1.24681.1.2.12.0 | awk '{print $4}' | sed 's/^"\(.*\).$/\1/')
 	hdnum=$(snmpget -v1 -c "$strCommunity" "$strHostname"  .1.3.6.1.4.1.24681.1.2.10.0 | awk '{print $4}')
 	VOLCOUNT=$(snmpget -v1 -c "$strCommunity" "$strHostname" .1.3.6.1.4.1.24681.1.2.16.0 | awk '{print $4}')
-	name=$(snmpget -v1 -c "$strCommunity" "$strHostname"  .1.3.6.1.4.1.24681.1.2.13.0  | awk '{print $4}' | sed 's/^"\(.*\).$/\1/')
+	name=$(snmpget -v1 -c "$strCommunity" "$strHostname"  .1.3.6.1.4.1.24681.1.2.13.0  | awk '{print $4}' | sed 's/^"\(.*\)$/\1/')
+	firmware=$(snmpget -v1 -c "$strCommunity" "$strHostname"  .1.3.6.1.2.1.47.1.1.1.1.9.1 | awk '{print $4}' | sed 's/^"\(.*\)$/\1/')
 
-	echo NAS $name Model $model, Max HD number $hdnum, No. Volume $VOLCOUNT
+	echo NAS $name Model $model, Firmware $firmware, Max HD number $hdnum, No. Volume $VOLCOUNT
 	exit 0
 
 #----------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- The last letter of the NAS NAME was trimmed. So "NAS-RTD-1"  became
"NAS-RTD-".
- Presentation of the firmware-version in the sysinfo command.