### PR TITLE
Changed the hdstatus check to use the storageManager.* OIDs.

### DIFF
--- a/check_qnap3.sh
+++ b/check_qnap3.sh
@@ -28,7 +28,7 @@ if [ ! "$#" == "5" ]; then
         echo
 	echo "Usage: ./check_qnap <hostname> <community> <part> <warning> <critical>"
         echo
-	echo "Parts are: sysinfo, systemuptime, temp, cpu, cputemp, freeram, powerstatus, fans, diskused, hdstatus, hd#status, hd#temp, volstatus (Raid Volume Status), vol#status"
+	echo "Parts are: sysinfo, systemuptime, temp, cpu, cputemp, freeram, powerstatus, fans, diskused, hdstatus, hd#status, hd#temp, hdtemp, volstatus (Raid Volume Status), vol#status"
         echo
 	echo "hdstatus shows status & temp; volstatus check all vols and vols space; powerstatus check power supply"
         echo "<#> is 1-8 for hd, 1-5 for vol"
@@ -364,6 +364,40 @@ elif [ "$strpart" == "hd8temp" ]; then
                 echo "OK: "$OUTPUT
                 exit 0
         fi
+
+# ALL HDs TEMP ---------------------------------------------------------------------------------------------------------------------------------------
+# Don't bother with perfdata, this plugin is simply to make us aware of a potential issue. The QNAP interface can give us details.
+elif [ "$strpart" == "hdtemp" ]; then
+
+    hdnum=$(snmpget -v2c -c "$strCommunity" "$strHostname"  1.3.6.1.4.1.24681.1.4.1.1.1.1.5.1.0 | awk '{print $4}')
+
+    output="OK: ($hdnum disks)"
+    ret=0
+
+	for (( c=1; c<=$hdnum; c++ ))
+	do
+	   TEMPHD=$(snmpget -v2c -c "$strCommunity" -mALL "$strHostname" 1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.6.$c | awk '{print $4}')
+	   if [ ${TEMPHD} -ge "$strWarning" ]; then
+
+	        if [ ${ret} -eq 0 ]; then
+	            output=""
+	            ret=1
+            fi
+
+	        ENC=$(snmpget -v2c -c "$strCommunity" -mALL "$strHostname" 1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.3.$c | awk '{print $4}')
+            ID=$(snmpget -v2c -c "$strCommunity" -mALL "$strHostname" 1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.2.$c | awk '{print $4}')
+
+            if [ ${TEMPHD} -ge "$strCritical" ]; then
+                ret=2
+                output+="CRITICAL: Disk ${ID} in enclosure ${ENC} is ${TEMPHD}C \n"
+            else
+                output+="WARN: Disk ${ID} in enclosure ${ENC} is ${TEMPHD}C \n"
+            fi
+	   fi
+	done
+
+	printf "$output"
+	exit ${ret}
 
 # Volume 1 Status----------------------------------------------------------------------------------------------------------------------------------------
 elif [ "$strpart" == "vol1status" ]; then

--- a/check_qnap3.sh
+++ b/check_qnap3.sh
@@ -544,17 +544,16 @@ elif [ "$strpart" == "hd8status" ]; then
 # HD Status----------------------------------------------------------------------------------------------------------------------------------------
 elif [ "$strpart" == "hdstatus" ]; then
 
-	hdnum=$(snmpget -v2c -c "$strCommunity" "$strHostname"  .1.3.6.1.4.1.24681.1.2.10.0 | awk '{print $4}')
+	hdnum=$(snmpget -v2c -c "$strCommunity" "$strHostname"  1.3.6.1.4.1.24681.1.4.1.1.1.1.5.1.0 | awk '{print $4}')
 
         hdok=0
         hdnop=0
 	output_crit=""
-	
+
 	for (( c=1; c<=$hdnum; c++ ))
 	do
-	   HD=$(snmpget -v2c -c "$strCommunity" -mALL "$strHostname" 1.3.6.1.4.1.24681.1.2.11.1.7.$c | awk '{print $4}' | sed 's/^"\(.*\).$/\1/')
-	   
-	   if [ "$HD" == "GOOD" ]; then
+	   HD=$(snmpget -v2c -c "$strCommunity" -mALL "$strHostname" 1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.4.$c | awk '{print $4}' | sed 's/^"\(.*\).$/\1/')
+	   if [ ${HD^^} == "GOOD" ]; then
             	hdok=$(echo "scale=0; $hdok+1" | bc -l)
     	   elif [ "$HD" == "--" ]; then    	        
     	        hdnop=$(echo "scale=0; $hdnop+1" | bc -l)


### PR DESCRIPTION
I'm not sure whether this goes against your orignal intentions for this script, so feel free to tell me to naff off.

Your script uses OIDs within systemInfo.systemHdTable.* to get information about local disks within the NAS. The problem we have is that our NASs have external enclosures connected via SAS (which cannot be checked independently). 

I've changed the hdstatus function to use the OIDs within storageManager.nasStorage.components.disk.* - this includes all disks both on the NAS and all connected enclosures.

I also used functionality for BaSH v4+ only, to uppercase the status string. BaSH 4 is fairly commonplace now, so I hope this isn't a problem.

Cheers,

Jon